### PR TITLE
Added A Rake task to install plugin from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,19 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
 .DS_Store
-*.xcuserdatad
+test-report.xml
+test-reports
+.idea

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require File.expand_path('lib/rake_config')
+require File.expand_path('lib/rake_helper')
+
+include RakeHelper
+
+Dir['lib/tasks/*.rake'].each do |file|
+  load File.expand_path(file)
+end
+
+task :default => "buildit:install"

--- a/lib/rake_config.rb
+++ b/lib/rake_config.rb
@@ -1,0 +1,8 @@
+PROJECT_NAME = "BetterConsole"
+APP_NAME = "BetterConsole"
+CONFIGURATION = "Release"
+
+SDK_VERSION = "6.0"
+
+PROJECT_ROOT = File.expand_path('../..', __FILE__)
+BUILD_DIR = File.join(PROJECT_ROOT, "build")

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -1,0 +1,24 @@
+module RakeHelper
+  def build_dir(effective_platform_name)
+    File.join(BUILD_DIR, CONFIGURATION + effective_platform_name)
+  end
+
+  def system_or_exit(cmd, stdout = nil)
+    puts "Executing #{cmd}"
+    cmd += " > #{stdout}" if stdout
+    system(cmd) or raise "******** Build failed ********"
+  end
+
+  def output_file(target)
+    output_dir = if ENV['IS_CI_BOX']
+                   ENV['CC_BUILD_ARTIFACTS']
+                 else
+                   Dir.mkdir(BUILD_DIR) unless File.exists?(BUILD_DIR)
+                   BUILD_DIR
+                 end
+
+    output_file = File.join(output_dir, "#{target}.output")
+    puts "Output: #{output_file}"
+    output_file
+  end
+end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,0 +1,13 @@
+namespace :buildit do
+  desc "Build project"
+  task :install => :clean do
+    puts "xcodebuild -project #{PROJECT_NAME}.xcodeproj -configuration #{CONFIGURATION}  install"
+    system_or_exit "xcodebuild -project #{PROJECT_NAME}.xcodeproj -configuration #{CONFIGURATION}  install", output_file("install")
+  end
+
+  desc "Clean project"
+  task :clean do
+    puts "rm -rf #{BUILD_DIR}/*"
+    system_or_exit "rm -rf #{BUILD_DIR}/*", output_file("clean")
+  end
+end


### PR DESCRIPTION
I added a rake task so the plugin can be installed from the command line. This is useful for script based configuration solutions like [Chef](http://www.opscode.com/chef/). 

You you can simply type : `rake`

And this will install the plugin on the local machine.
