### PR TITLE
Fix: allow plugin to load on Xcode5 DP3

### DIFF
--- a/BetterConsole/Info.plist
+++ b/BetterConsole/Info.plist
@@ -26,5 +26,9 @@
 	<false/>
 	<key>XC4Compatible</key>
 	<true/>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Same fix as the one for the CedarShortcuts plugin
