### PR TITLE
Changed regex to avoid false positives

### DIFF
--- a/BetterConsole/BCFilePathHighlighter.m
+++ b/BetterConsole/BCFilePathHighlighter.m
@@ -23,7 +23,7 @@
     static regex_t *rx = NULL;
     if (!rx) {
         rx = malloc(sizeof(regex_t));
-        regcomp(rx, "([/\\*][^:\n\r]+:[[:digit:]]+)", REG_EXTENDED);
+        regcomp(rx, "([\\*]?/[^:\n\r]+:[[:digit:]]+)", REG_EXTENDED);
     }
     return *rx;
 }


### PR DESCRIPTION
Current regex falsely triggered for a such string:

```
*** Assertion failure in -[UICollectionView _endItemAnimations], /SourceCache/UIKit_Sim/UIKit-2903.23/UICollectionView.m:3716
```

It matches a full string, while the new one matches only file path(`/SourceCache/UIKit_Sim/UIKit-2903.23/UICollectionView.m:3716`).
See links below:

Before: http://regexr.com/?38jid
After: http://regexr.com/?38jig
